### PR TITLE
Add automated test for EPAM client work page

### DIFF
--- a/tests/example_scenario.spec.ts
+++ b/tests/example_scenario.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EPAM Website Navigation', () => {
+  test('Verify Client Work page navigation and text visibility', async ({ page }) => {
+    // Step 1: Navigate to https://www.epam.com/
+    await page.goto('https://www.epam.com/');
+
+    // Step 2: Select “Services” from the header menu inside the `top-navigation__row` element
+    const servicesMenu = page.locator('.top-navigation__row >> text=Services');
+    await servicesMenu.click();
+
+    // Step 3: Click the “Explore Our Client Work” link
+    const clientWorkLink = page.locator('text=Explore Our Client Work');
+    await clientWorkLink.click();
+
+    // Step 4: Verify that the “Client Work” text is visible on the page
+    const clientWorkText = page.locator('text=Client Work');
+    await expect(clientWorkText).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request adds a Playwright test script for the following scenario:

1. Navigate to [https://www.epam.com/](https://www.epam.com/)
2. Select “Services” from the header menu inside the `top-navigation__row` element
3. Click the “Explore Our Client Work” link
4. Verify that the “Client Work” text is visible on the page

The test script ensures that the navigation and verification steps are automated and validated.