### PR TITLE
Add automated test for EPAM client work page

### DIFF
--- a/src/example_scenario.ts
+++ b/src/example_scenario.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EPAM Website Client Work Test', () => {
+  test('Verify Client Work Page', async ({ page }) => {
+    // Step 1: Navigate to EPAM website
+    await page.goto('https://www.epam.com/');
+
+    // Step 2: Select "Services" from the header menu
+    const servicesMenu = page.locator('.top-navigation__row >> text=Services');
+    await servicesMenu.click();
+
+    // Step 3: Click "Explore Our Client Work" link
+    const clientWorkLink = page.locator('text=Explore Our Client Work');
+    await clientWorkLink.click();
+
+    // Step 4: Verify "Client Work" text is visible on the page
+    const clientWorkText = page.locator('text=Client Work');
+    await expect(clientWorkText).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request adds an automated Playwright test script for verifying the "Client Work" page on the EPAM website. The test script includes the following steps:

1. Navigate to the EPAM website.
2. Select "Services" from the header menu.
3. Click the "Explore Our Client Work" link.
4. Verify that the "Client Work" text is visible on the page.

The script is located in `src/example_scenario.ts`.