### PR TITLE
Add automated test for EPAM client work page

### DIFF
--- a/tests/epamscenario.spec.ts
+++ b/tests/epamscenario.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('EPAM Website Test', () => {
+  test('Verify Client Work Text Visibility', async ({ page }) => {
+    // Step 1: Navigate to EPAM website
+    await page.goto('https://www.epam.com/');
+
+    // Step 2: Select "Services" from the header menu
+    const servicesMenu = page.locator('.top-navigation__row >> text=Services');
+    await servicesMenu.click();
+
+    // Step 3: Click "Explore Our Client Work" link
+    const exploreClientWorkLink = page.locator('text=Explore Our Client Work');
+    await exploreClientWorkLink.click();
+
+    // Step 4: Verify "Client Work" text is visible
+    const clientWorkText = page.locator('text=Client Work');
+    await expect(clientWorkText).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request adds a Playwright test script to verify the visibility of the 'Client Work' text on the EPAM website. The test performs the following steps:\n\n1. Navigates to the EPAM website.\n2. Selects 'Services' from the header menu.\n3. Clicks the 'Explore Our Client Work' link.\n4. Verifies that the 'Client Work' text is visible on the page.